### PR TITLE
Fix next/link should be used with anchor as children

### DIFF
--- a/src/templates/dapp/DAppBase.tsx
+++ b/src/templates/dapp/DAppBase.tsx
@@ -20,7 +20,9 @@ const DAppBase = () => (
         <NavbarTwoColumns logo={<Logo xl />}>
           <li>
             <Link href="https://neow3j.io">
-              <Button>Help?</Button>
+              <a>
+                <Button>Help?</Button>
+              </a>
             </Link>
           </li>
         </NavbarTwoColumns>


### PR DESCRIPTION
Next Link should have an anchor as children.

![Captura de tela de 2021-10-23 15-51-23](https://user-images.githubusercontent.com/51221635/138568188-345e718f-0972-436e-ae1d-c720813fe841.png)


https://nextjs.org/docs/api-reference/next/link